### PR TITLE
linter passed

### DIFF
--- a/terraform-05/main.tf
+++ b/terraform-05/main.tf
@@ -24,7 +24,7 @@ resource "yandex_vpc_subnet" "develop_b" {
 #-------------------------------------------------------------------
 
 module "test-vm" {
-  source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=86ebea2f6cd4a1798c233a9025783da2048f8509"
   env_name       = var.vpc_name1
 #  network_id     = yandex_vpc_network.develop.id
   network_id	 = module.vpc.netko.id
@@ -49,7 +49,7 @@ module "test-vm" {
 }
 
 module "example-vm" {
-  source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=86ebea2f6cd4a1798c233a9025783da2048f8509"
   env_name       = var.vpc_name2
 #  network_id     = yandex_vpc_network.develop.id
   network_id     = module.vpc.netko.id

--- a/terraform-05/providers.tf
+++ b/terraform-05/providers.tf
@@ -2,6 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.129.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"
     }
   }
   required_version = ">=1.8.4"

--- a/terraform-05/variables.tf
+++ b/terraform-05/variables.tf
@@ -16,10 +16,6 @@ variable "cidr" {
 }
 
 ###cloud vars
-variable "token" {
-  type        = string
-  description = "OAuth-token; https://cloud.yandex.ru/docs/iam/concepts/authorization/oauth-token"
-}
 
 variable "cloud_id" {
   type        = string
@@ -36,11 +32,7 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
+
 
 variable "vpc_name1" {
   type        = string
@@ -74,20 +66,7 @@ variable "labels2" {
 
 
 
-# ------- Map variables -------
-variable "metamaps" {
-    type = map(object({
-        serial = bool
-        ssh = string
-    }))
-    default = {
-        "meta" = {
-            serial = true
-            ssh = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoBYtkaOTscrqxn5/GDjg2Q0rJ6wqRwyQ42aNseGYuL yan"
-        }
-    }
-}
-
+#
 # ------- for cloudinit -------
 
 variable "public_key" {


### PR DESCRIPTION
---- TFLINT ------
viveka@tulsi-VMware:~/git/terraform-05$ tflint
7 issue(s) found:

Warning: Module source "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 27:
  27:   source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 52:
  52:   source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "token" is declared but not used (terraform_unused_declarations)

  on variables.tf line 19:
  19: variable "token" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 39:
  39: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "metamaps" is declared but not used (terraform_unused_declarations)

  on variables.tf line 78:
  78: variable "metamaps" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on variables.tf line 103:
 103: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

---- CHECKOV -----

viveka@tulsi-VMware:~/git/terraform-05$ checkov -d ~/git/terraform-05
2024-11-27 07:30:00,726 [MainThread  ] [WARNI]  Failed to get the checkov mappings and guidelines from https://api0.prismacloud.io/bridgecrew/api/v2/guidelines. Skips using BC_* IDs will not work.
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 203, in _new_conn
    sock = connection.create_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/util/connection.py", line 85, in create_connection
    raise err
  File "/usr/lib/python3/dist-packages/urllib3/util/connection.py", line 73, in create_connection
    sock.connect(sa)
TimeoutError: timed out

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 791, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 492, in _make_request
    raise new_e
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 468, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 1097, in _validate_conn
    conn.connect()
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 611, in connect
    self.sock = sock = self._new_conn()
                       ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 212, in _new_conn
    raise ConnectTimeoutError(
urllib3.exceptions.ConnectTimeoutError: (<urllib3.connection.HTTPSConnection object at 0x74c7ce24a750>, 'Connection to api0.prismacloud.io timed out. (connect timeout=3.1)')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/viveka/.local/lib/python3.12/site-packages/checkov/common/bridgecrew/platform_integration.py", line 1273, in get_public_run_config
    request = self.http.request("GET", self.guidelines_api_url, headers=headers)  # type:ignore[no-untyped-call]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/_request_methods.py", line 110, in request
    return self.request_encode_url(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/_request_methods.py", line 143, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/poolmanager.py", line 443, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 875, in urlopen
    return self.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 875, in urlopen
    return self.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 875, in urlopen
    return self.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 845, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/util/retry.py", line 517, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api0.prismacloud.io', port=443): Max retries exceeded with url: /bridgecrew/api/v2/guidelines (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x74c7ce24a750>, 'Connection to api0.prismacloud.io timed out. (connect timeout=3.1)'))
2024-11-27 07:30:00,763 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main:None (for external modules, the --download-external-modules flag is required)
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ terraform framework ]: 100%|████████████████████|[8/8], Current File Scanned=vpc/variables_mod.tf   
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml


       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.307 
Update available 3.2.307 -> 3.2.317
Run pip3 install -U checkov to update 


terraform scan results:

Passed checks: 0, Failed checks: 4, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	FAILED for resource: test-vm
	File: /main.tf:26-49

		26 | module "test-vm" {
		27 |   source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"
		28 |   env_name       = var.vpc_name1
		29 | #  network_id     = yandex_vpc_network.develop.id
		30 |   network_id	 = module.vpc.netko.id
		31 |   subnet_zones   = [var.default_zone]
		32 | #  subnet_ids     = [yandex_vpc_subnet.develop_a.id,yandex_vpc_subnet.develop_b.id]
		33 |   subnet_ids     = [module.vpc.subway.id]
		34 |   instance_name  = var.vpc_name1
		35 |   instance_count = 1
		36 |   image_family   = var.vm_web_family
		37 |   public_ip      = var.pub-ip
		38 | 
		39 |   labels = { 
		40 |  #   owner= "viktor",
		41 |     project = var.labels1
		42 |      }
		43 | 
		44 |   metadata = {
		45 |     user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
		46 |     serial-port-enable = 1
		47 |   }
		48 | 
		49 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	FAILED for resource: test-vm
	File: /main.tf:26-49

		26 | module "test-vm" {
		27 |   source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"
		28 |   env_name       = var.vpc_name1
		29 | #  network_id     = yandex_vpc_network.develop.id
		30 |   network_id	 = module.vpc.netko.id
		31 |   subnet_zones   = [var.default_zone]
		32 | #  subnet_ids     = [yandex_vpc_subnet.develop_a.id,yandex_vpc_subnet.develop_b.id]
		33 |   subnet_ids     = [module.vpc.subway.id]
		34 |   instance_name  = var.vpc_name1
		35 |   instance_count = 1
		36 |   image_family   = var.vm_web_family
		37 |   public_ip      = var.pub-ip
		38 | 
		39 |   labels = { 
		40 |  #   owner= "viktor",
		41 |     project = var.labels1
		42 |      }
		43 | 
		44 |   metadata = {
		45 |     user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
		46 |     serial-port-enable = 1
		47 |   }
		48 | 
		49 | }

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	FAILED for resource: example-vm
	File: /main.tf:51-74

		51 | module "example-vm" {
		52 |   source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"
		53 |   env_name       = var.vpc_name2
		54 | #  network_id     = yandex_vpc_network.develop.id
		55 |   network_id     = module.vpc.netko.id
		56 |   subnet_zones   = [var.default_zone]
		57 | #  subnet_ids     = [yandex_vpc_subnet.develop_a.id]
		58 |   subnet_ids     = [module.vpc.subway.id]
		59 |   instance_name  = var.vpc_name2
		60 |   instance_count = 1
		61 |   image_family   = var.vm_web_family
		62 |   public_ip      = var.pub-ip
		63 | 
		64 |   labels = { 
		65 | #    owner= "viktor",
		66 |     project = var.labels2
		67 |      }
		68 | 
		69 |   metadata = {
		70 |     user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
		71 |     serial-port-enable = 1
		72 |   }
		73 | 
		74 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	FAILED for resource: example-vm
	File: /main.tf:51-74

		51 | module "example-vm" {
		52 |   source         = "git::https://github.com/Heimdier/yandex_compute_instance.git?ref=main"
		53 |   env_name       = var.vpc_name2
		54 | #  network_id     = yandex_vpc_network.develop.id
		55 |   network_id     = module.vpc.netko.id
		56 |   subnet_zones   = [var.default_zone]
		57 | #  subnet_ids     = [yandex_vpc_subnet.develop_a.id]
		58 |   subnet_ids     = [module.vpc.subway.id]
		59 |   instance_name  = var.vpc_name2
		60 |   instance_count = 1
		61 |   image_family   = var.vm_web_family
		62 |   public_ip      = var.pub-ip
		63 | 
		64 |   labels = { 
		65 | #    owner= "viktor",
		66 |     project = var.labels2
		67 |      }
		68 | 
		69 |   metadata = {
		70 |     user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
		71 |     serial-port-enable = 1
		72 |   }
		73 | 
		74 | }
